### PR TITLE
Add timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This project is about implementing the various container types of the C++ standa
 * [Type_traits](#Type_traits)
     * [enable_if](#enable_if)
     * [is_integral](#is_integral)
+* [Clock](#clock)
+
 # Vector
 
 >std::vector is a sequence container that encapsulates dynamic size arrays
@@ -592,3 +594,23 @@ int main() {
 i is odd: true
 i is even: false
 ```
+
+# Clock
+
+[from cplusplus reference](https://www.cplusplus.com/reference/ctime/clock/)
+
+`clock_t clock (void)`
+
+Returns the processor time consumed by the program.
+
+The value returned is expressed in clock ticks, which are units of time of a constant but system-specific length (with a relation of CLOCKS_PER_SEC clock ticks per second).
+
+The epoch used as reference by clock varies between systems, but it is related to the program execution (generally its launch). To calculate the actual processing time of a program, the value returned by clock shall be compared to a value returned by a previous call to the same function.
+
+**Return Value**:
+
+The number of clock ticks elapsed since an epoch related to the particular program execution.
+
+On failure, the function returns a value of -1.
+
+clock_t is a type defined in <ctime> as an alias of a fundamental arithmetic type.

--- a/tests/ft_main.cpp
+++ b/tests/ft_main.cpp
@@ -6,11 +6,12 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/11 19:35:20 by phemsi-a          #+#    #+#             */
-/*   Updated: 2022/02/22 20:18:33 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2022/02/22 21:42:49 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "tests.hpp"
+#include <time.h>
 
 static ft::vector<int> test_push_back(void)
 {
@@ -290,6 +291,12 @@ static void test_swap(void)
 
 int main(void)
 {
+	clock_t start;
+	clock_t end;
+	clock_t elapsed_time;
+
+	start = clock();
+
 	test_constructors();
 	test_empty();
 	test_pop_back(test_push_back());
@@ -309,4 +316,8 @@ int main(void)
 	test_insert();
 	test_relational_operators();
 	test_swap();
+
+	end = clock();
+	elapsed_time = end - start;
+	std::cout << "Test duration:" << static_cast<float>(elapsed_time) / CLOCKS_PER_SEC << std::endl;
 }


### PR DESCRIPTION
Adicionando duração dos testes a partir da função [clock()](https://www.cplusplus.com/reference/ctime/clock/)