### PR TITLE
Adapt tester to be use for map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+         #
+#    By: lfrasson <lfrasson@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/03/04 17:27:40 by lfrasson          #+#    #+#              #
-#    Updated: 2022/03/04 23:21:20 by phemsi-a         ###   ########.fr        #
+#    Updated: 2022/03/06 15:44:05 by lfrasson         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -20,16 +20,20 @@ TESTS_DIR	:=	./tests/
 VECTOR_TEST_DIR	:=	$(TESTS_DIR)vector
 MAP_TEST_DIR	:=	$(TESTS_DIR)map
 
+all:	vector_test map_test
+
 vector_test:
 		make -C $(VECTOR_TEST_DIR)
 
 map_test:
 		make -C $(MAP_TEST_DIR)
 
-all:	vector_test map_test
+vector_script:
+		$(TESTER) vector
 
-test:
-		$(TESTER)
+map_script:
+		$(TESTER) map
+
 clean:
 		make clean -C $(VECTOR_TEST_DIR)
 		make clean -C $(MAP_TEST_DIR)

--- a/tester.sh
+++ b/tester.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
 RESET="\033[0m"
+BOLD="\033[1m"
+RED="\033[0;31m"
 V_GREEN="\e[0;38;5;82m"
 P_GREEN="\e[0;38;5;23m"
+
+DIFF=diff --collor
+if [ "$(eval uname)" == "Darwin" ]
+then
+    DIFF=diff
+    V_GREEN="\033[32m"
+fi
+
 
 LOGSDIR=./logs/
 VECTORDIR=./tests/vector/
@@ -22,4 +32,4 @@ mkdir -p ${LOGSDIR}
 ${VECTORDIR}original > ${LOGSDIR}std.txt 2> ${LOGSDIR}exceptions.txt
 ${VECTORDIR}ft.out > ${LOGSDIR}ft.txt 2>> ${LOGSDIR}exceptions.txt
 
-diff --color ${LOGSDIR}std.txt ${LOGSDIR}ft.txt
+${DIFF} ${LOGSDIR}std.txt ${LOGSDIR}ft.txt

--- a/tester.sh
+++ b/tester.sh
@@ -5,7 +5,7 @@ V_GREEN="\e[0;38;5;82m"
 P_GREEN="\e[0;38;5;23m"
 
 LOGSDIR=./logs/
-VECTORDIR=./tests/
+VECTORDIR=./tests/vector/
 
 echo -e "\n${V_GREEN} ----------making std version----------\n${RESET}"
 

--- a/tester.sh
+++ b/tester.sh
@@ -6,30 +6,50 @@ RED="\033[0;31m"
 V_GREEN="\e[0;38;5;82m"
 P_GREEN="\e[0;38;5;23m"
 
-DIFF=diff --collor
-if [ "$(eval uname)" == "Darwin" ]
-then
-    DIFF=diff
-    V_GREEN="\033[32m"
+usage()
+{
+	echo -e "usage:"
+	echo -e "bash tester.sh vector"
+	echo -e "bash tester.sh map"
+	exit
+}
+
+if (( $# != 1 )); then
+    usage
 fi
 
+ARG=$1
+if [ ${ARG} == "vector" ]; then
+    DIR=./tests/vector/
+elif [ ${ARG} == "map" ]; then
+    DIR=./tests/map/
+else
+	echo -e "\""$1"\" is not a valid argument."
+    usage
+fi
+
+if [ "$(eval uname)" == "Darwin" ]; then
+    DIFF=diff
+    V_GREEN="\033[32m"
+else
+    DIFF=diff --collor
+fi
 
 LOGSDIR=./logs/
-VECTORDIR=./tests/vector/
 
 echo -e "\n${V_GREEN} ----------making std version----------\n${RESET}"
 
-make -C ${VECTORDIR} original
+make -C ${DIR} original
 
 echo -e "\n${V_GREEN} ----------making ft version----------\n${RESET}"
 
-make -C ${VECTORDIR} 
+make -C ${DIR}
 
 echo -e "\n${V_GREEN} ----------executing and comparing----------\n${RESET}"
 
 mkdir -p ${LOGSDIR}
 
-${VECTORDIR}original > ${LOGSDIR}std.txt 2> ${LOGSDIR}exceptions.txt
-${VECTORDIR}ft.out > ${LOGSDIR}ft.txt 2>> ${LOGSDIR}exceptions.txt
+${DIR}original > ${LOGSDIR}std.txt 2> ${LOGSDIR}exceptions.txt
+${DIR}ft.out > ${LOGSDIR}ft.txt 2>> ${LOGSDIR}exceptions.txt
 
 ${DIFF} ${LOGSDIR}std.txt ${LOGSDIR}ft.txt

--- a/tester.sh
+++ b/tester.sh
@@ -32,7 +32,7 @@ if [ "$(eval uname)" == "Darwin" ]; then
     DIFF=diff
     V_GREEN="\033[32m"
 else
-    DIFF=diff --collor
+    DIFF="diff --color"
 fi
 
 LOGSDIR=./logs/

--- a/tests/map/Makefile
+++ b/tests/map/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+         #
+#    By: lfrasson <lfrasson@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/12/04 18:38:38 by phemsi-a          #+#    #+#              #
-#    Updated: 2022/03/05 20:23:35 by phemsi-a         ###   ########.fr        #
+#    Updated: 2022/03/06 15:46:04 by lfrasson         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -97,6 +97,6 @@ fclean:		clean
 re:			fclean all
 
 test:
-		make map_test -C $(ROOT)
+		make map_script -C $(ROOT)
 
 PHONY:		all clean fclean re test

--- a/tests/vector/Makefile
+++ b/tests/vector/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+         #
+#    By: lfrasson <lfrasson@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/12/04 18:38:38 by phemsi-a          #+#    #+#              #
-#    Updated: 2022/03/04 23:22:43 by phemsi-a         ###   ########.fr        #
+#    Updated: 2022/03/06 15:45:26 by lfrasson         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -117,6 +117,6 @@ fclean:		clean
 re:			fclean all
 
 test:
-		make vector_test -C $(ROOT)
+		make vector_script -C $(ROOT)
 
 PHONY:		all clean fclean re test


### PR DESCRIPTION
- Condição para deixar o tester compatível com macos
- Tester aceitando parâmetros para funcionar para vector ou map
- `make test` dentro dos diretórios de cada roda o respectivo script