### PR TITLE
Fix leaks

### DIFF
--- a/containers/Map.hpp
+++ b/containers/Map.hpp
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/28 21:20:16 by lfrasson          #+#    #+#             */
-/*   Updated: 2022/04/06 21:43:15 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2022/04/06 22:10:14 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,6 +86,11 @@ namespace ft
 			map (const map& other)
 			{
 				*this = other;	
+			}
+			
+			~map (void)
+			{
+				btree_delete_tree(this->_root);
 			}
 			
 			key_compare key_comp(void) const

--- a/rb_tree/includes/rb_tree.hpp
+++ b/rb_tree/includes/rb_tree.hpp
@@ -17,6 +17,7 @@
 #include "btree_next.tpp"
 #include "btree_previous.tpp"
 #include "btree_search_item.tpp"
+#include "btree_delete_tree.tpp"
 
 // #include "compare.tpp"
 // #include "print_item.tpp"

--- a/tests/map/insert.cpp
+++ b/tests/map/insert.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   insert.cpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lfrasson <lfrasson@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/06 19:01:21 by lfrasson          #+#    #+#             */
-/*   Updated: 2022/04/06 20:17:01 by lfrasson         ###   ########.fr       */
+/*   Updated: 2022/04/06 22:07:26 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,15 +29,15 @@ static void print(ft::pair<ft::map<int, int>::iterator, bool> insert_return)
 				<< RESET << std::endl;
 }
 
-static void insert(ft::map<int, int> &map, ft::pair<const int, int> *pair)
+static void insert(ft::map<int, int> &map, ft::pair<const int, int> pair)
 {
 	ft::pair<ft::map<int, int>::iterator, bool>	insert_return;
 	
 	std::cout << "insert pair ("
-				<< pair->first << ", "
-				<< pair->second << ") to map"
+				<< pair.first << ", "
+				<< pair.second << ") to map"
 				<< std::endl;
-	insert_return = map.insert(*pair);
+	insert_return = map.insert(pair);
 	print(insert_return);	
 }
 
@@ -47,8 +47,8 @@ void	test_insert(void)
 	
 	ft::map<int, int>	map;
 
-	insert(map, new ft::pair<const int, int>(1, 111));	
-	insert(map, new ft::pair<const int, int>(2, 222));	
-	insert(map, new ft::pair<const int, int>(1, 1));	
-	insert(map, new ft::pair<const int, int>(2, 2));	
+	insert(map, ft::make_pair(1, 1110));
+	insert(map, ft::make_pair(2, 222));	
+	insert(map, ft::make_pair(1, 1));	
+	insert(map, ft::make_pair(2, 2));	
 }

--- a/tests/map/utils.cpp
+++ b/tests/map/utils.cpp
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/22 13:57:55 by lfrasson          #+#    #+#             */
-/*   Updated: 2022/04/06 18:57:10 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2022/04/06 21:59:59 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,8 +37,8 @@ ft::map<int, int>	create_map_of_random_integers(int size, int seed)
     {
         int random = random_number();
         std::cout << "include " << random << ", " << random << " to map" << std::endl;
-        const ft::pair<const int, int>	*pair = new ft::pair<const int, int>(random, random);
-	    map.insert(*pair);
+        const ft::pair<const int, int>	pair(random, random);
+	    map.insert(pair);
     }
     return map;
 }
@@ -52,8 +52,8 @@ ft::map<float, float>	create_map_of_floats(int size)
     {
         float float_to_insert = i/10 * i;
         std::cout << "include " << float_to_insert << ", " << float_to_insert << " to map" << std::endl;
-        const ft::pair<const float, float>	*pair = new ft::pair<const float, float>(float_to_insert, float_to_insert);
-        map.insert(*pair);
+        const ft::pair<const float, float>	pair(float_to_insert, float_to_insert);
+        map.insert(pair);
     }
     return map;
 }


### PR DESCRIPTION
Agora que o map faz uma cópia dos pairs passados deu pra deixar alocado na stack mesmo nos testes pra facilitar e não precisar desalocá-los. Usando o delete da btree, mas ele vai precisar de uns refacts pq ele destrói os itens, então assim que implementarmos isso no map dá pra mexer nela pra destruir só os nodes ✨ 
*ps. se bem que pode fazer sentido ela mesma deletar pq neste momento é o que ainda ficou na árvore e queremos mesmo apagar todos*